### PR TITLE
feat(api): add Swagger documentation and schemas

### DIFF
--- a/apps/api/src/app/account/account.controller.ts
+++ b/apps/api/src/app/account/account.controller.ts
@@ -1,5 +1,16 @@
 import { Controller, Get, Post, Query, Res, UseGuards } from '@nestjs/common';
 import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
+  accountDeletionStatusSchema,
+  accountSettingsSchema,
   AccountDeletionStatusDto,
   AccountSettingsDto,
   ChangeEmailRequestDto,
@@ -10,7 +21,7 @@ import {
   DeleteJobApplicationsDto,
   deleteJobApplicationsSchema,
 } from '@job-tracker-lite-angular/schemas';
-import { ZodBody } from '@job-tracker-lite-angular/core-utils';
+import { ZodBody, zodToApiSchema } from '@job-tracker-lite-angular/core-utils';
 import {
   AllowAnonymous,
   AuthGuard,
@@ -20,12 +31,20 @@ import {
 import { Response } from 'express';
 import { AccountService } from './account.service';
 
+@ApiTags('account')
 @Controller('account')
 export class AccountController {
   constructor(private readonly accountService: AccountService) {}
 
   @Get()
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get account settings',
+    description:
+      "Returns the current user's email, any pending email change, and verification status.",
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(accountSettingsSchema) })
   async getSettings(
     @Session() session: UserSession,
   ): Promise<AccountSettingsDto> {
@@ -34,6 +53,17 @@ export class AccountController {
 
   @Post('change-email')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Request an email change',
+    description:
+      'Sends a verification link to the new email address; the change only takes effect once the link is followed.',
+  })
+  @ApiBody({
+    description:
+      'New email address and the language to send the verification email in',
+    schema: zodToApiSchema(changeEmailRequestSchema),
+  })
   async changeEmail(
     @Session() session: UserSession,
     @ZodBody(changeEmailRequestSchema) body: ChangeEmailRequestDto,
@@ -48,6 +78,25 @@ export class AccountController {
 
   @Get('verify-email-change')
   @AllowAnonymous()
+  @ApiOperation({
+    summary: 'Confirm an email change',
+    description:
+      'Called by clicking the verification link sent to the new email address. Applies the pending email change, then redirects the browser to the frontend. Not meaningfully callable via "Try it out" since the result is a redirect.',
+  })
+  @ApiQuery({
+    name: 'token',
+    description:
+      'Email-change verification token from the link sent by POST /account/change-email',
+  })
+  @ApiQuery({
+    name: 'language',
+    description: 'Language to show the resulting frontend page in',
+  })
+  @ApiResponse({
+    status: 302,
+    description:
+      'Redirects to the frontend with the outcome of the verification',
+  })
   async verifyEmailChange(
     @Query('token') token: string,
     @Query('language') language: SupportLang,
@@ -62,6 +111,20 @@ export class AccountController {
 
   @Get('restore-email')
   @AllowAnonymous()
+  @ApiOperation({
+    summary: 'Undo a pending email change',
+    description:
+      'Called by clicking the "restore" link sent to the old email address when a change was requested. Cancels the pending email change, then redirects the browser to the frontend. Not meaningfully callable via "Try it out" since the result is a redirect.',
+  })
+  @ApiQuery({
+    name: 'token',
+    description:
+      'Email-restore token from the link sent by POST /account/change-email',
+  })
+  @ApiResponse({
+    status: 302,
+    description: 'Redirects to the frontend with the outcome of the restore',
+  })
   async restoreEmail(
     @Query('token') token: string,
     @Res() response: Response,
@@ -72,6 +135,16 @@ export class AccountController {
 
   @Post('delete/request')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Request account deletion',
+    description:
+      'Starts the grace-period deletion flow and emails a confirmation link. The account is not deleted until the link is confirmed.',
+  })
+  @ApiBody({
+    description: 'Language to send the confirmation email in',
+    schema: zodToApiSchema(deleteAccountSchema),
+  })
   async requestAccountDeletion(
     @Session() session: UserSession,
     @ZodBody(deleteAccountSchema) body: DeleteAccountDto,
@@ -85,6 +158,25 @@ export class AccountController {
 
   @Get('confirm-delete')
   @AllowAnonymous()
+  @ApiOperation({
+    summary: 'Confirm account deletion',
+    description:
+      'Called by clicking the confirmation link sent by POST /account/delete/request. Starts the grace period for deletion, then redirects the browser to the frontend. Not meaningfully callable via "Try it out" since the result is a redirect.',
+  })
+  @ApiQuery({
+    name: 'token',
+    description:
+      'Account-deletion confirmation token from the link sent by POST /account/delete/request',
+  })
+  @ApiQuery({
+    name: 'language',
+    description: 'Language to show the resulting frontend page in',
+  })
+  @ApiResponse({
+    status: 302,
+    description:
+      'Redirects to the frontend with the outcome of the confirmation',
+  })
   async confirmAccountDeletion(
     @Query('token') token: string,
     @Query('language') language: SupportLang,
@@ -99,6 +191,13 @@ export class AccountController {
 
   @Get('delete/status')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Get account deletion status',
+    description:
+      'Returns whether the account is active or pending deletion, and the scheduled deletion date if applicable.',
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(accountDeletionStatusSchema) })
   async getDeletionStatus(
     @Session() session: UserSession,
   ): Promise<AccountDeletionStatusDto> {
@@ -107,18 +206,40 @@ export class AccountController {
 
   @Post('delete/recover')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Cancel a pending account deletion',
+    description:
+      'Reverses a previously confirmed deletion request, while still inside the grace period.',
+  })
   async recoverDeletion(@Session() session: UserSession): Promise<void> {
     await this.accountService.recoverAccountDeletion(session.user.id);
   }
 
   @Get('export-data')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Export account data',
+    description:
+      'Returns all data associated with the authenticated user, for download (GDPR data portability).',
+  })
   async exportData(@Session() session: UserSession) {
     return this.accountService.exportUserData(session.user.id);
   }
 
   @Post('delete/jobs')
   @UseGuards(AuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Bulk delete job applications',
+    description:
+      'Permanently deletes the job applications matching the given filter, for the authenticated user.',
+  })
+  @ApiBody({
+    description: 'Filter describing which job applications to delete',
+    schema: zodToApiSchema(deleteJobApplicationsSchema),
+  })
   async deleteJobs(
     @Session() session: UserSession,
     @ZodBody(deleteJobApplicationsSchema) body: DeleteJobApplicationsDto,

--- a/apps/api/src/app/healthcheck/healthcheck.controller.ts
+++ b/apps/api/src/app/healthcheck/healthcheck.controller.ts
@@ -1,8 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
 import { HealthCheck } from '@nestjs/terminus';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { AllowAnonymous } from '@thallesp/nestjs-better-auth';
 import { HealthService } from './healthcheck.service';
 
+@ApiTags('health')
 @AllowAnonymous()
 @Controller('health')
 export class HealthController {
@@ -11,6 +13,11 @@ export class HealthController {
   // Used by the orchestrator to decide whether to restart the process.
   @Get('live')
   @HealthCheck()
+  @ApiOperation({
+    summary: 'Liveness probe',
+    description:
+      'Checks whether the process itself is up. Used by the orchestrator to decide whether to restart the process.',
+  })
   live() {
     return this.healthService.checkLiveness();
   }
@@ -19,6 +26,11 @@ export class HealthController {
   // traffic to this instance.
   @Get('ready')
   @HealthCheck()
+  @ApiOperation({
+    summary: 'Readiness probe',
+    description:
+      'Checks whether the instance is ready to serve traffic (e.g. its dependencies are reachable). Used by the orchestrator/load balancer to decide whether to route traffic to it.',
+  })
   ready() {
     return this.healthService.checkReadiness();
   }
@@ -26,6 +38,11 @@ export class HealthController {
   // Not a liveness/readiness probe - for manual/dashboard checks only.
   @Get('detailed')
   @HealthCheck()
+  @ApiOperation({
+    summary: 'Detailed health report',
+    description:
+      'Runs the full set of health indicators. Not used by any probe - intended for manual/dashboard checks only.',
+  })
   detailed() {
     return this.healthService.checkDetailed();
   }

--- a/apps/api/src/app/jobs/contacts.controller.ts
+++ b/apps/api/src/app/jobs/contacts.controller.ts
@@ -6,8 +6,17 @@ import {
   Delete,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import {
+  contactSchema,
   ContactDto,
   contactIdParamSchema,
   CreateContactDto,
@@ -17,19 +26,38 @@ import {
   updateContactSchema,
 } from '@job-tracker-lite-angular/schemas';
 import { JobsService } from './jobs.service';
-import { ZodBody, ZodParam } from '@job-tracker-lite-angular/core-utils';
+import {
+  ZodBody,
+  ZodParam,
+  zodToApiSchema,
+} from '@job-tracker-lite-angular/core-utils';
 import {
   AuthGuard,
   Session,
   type UserSession,
 } from '@thallesp/nestjs-better-auth';
 
+@ApiTags('contacts')
+@ApiBearerAuth()
 @Controller('jobs/:id/contacts')
 @UseGuards(AuthGuard)
 export class ContactsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Get()
+  @ApiOperation({
+    summary: 'List contacts for a job application',
+    description:
+      'Returns every contact associated with the given job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiOkResponse({
+    schema: { type: 'array', items: zodToApiSchema(contactSchema) },
+  })
   async findContacts(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -38,6 +66,21 @@ export class ContactsController {
   }
 
   @Post()
+  @ApiOperation({
+    summary: 'Add a contact to a job application',
+    description:
+      'Creates a new contact linked to the given job application. Either an email or a phone number must be provided.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiBody({
+    description: 'Contact to create',
+    schema: zodToApiSchema(createContactSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(contactSchema) })
   async createContact(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -51,6 +94,25 @@ export class ContactsController {
   }
 
   @Patch(':contactId')
+  @ApiOperation({
+    summary: 'Update a contact',
+    description: 'Partially updates the fields of an existing contact.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiParam({
+    name: 'contactId',
+    description: 'Contact identifier (CUID2)',
+    schema: zodToApiSchema(contactIdParamSchema),
+  })
+  @ApiBody({
+    description: 'Fields to update on the contact',
+    schema: zodToApiSchema(updateContactSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(contactSchema) })
   async updateContact(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -66,6 +128,20 @@ export class ContactsController {
   }
 
   @Delete(':contactId')
+  @ApiOperation({
+    summary: 'Delete a contact',
+    description: 'Permanently deletes a contact from a job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiParam({
+    name: 'contactId',
+    description: 'Contact identifier (CUID2)',
+    schema: zodToApiSchema(contactIdParamSchema),
+  })
   async deleteContact(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,

--- a/apps/api/src/app/jobs/jobs.controller.ts
+++ b/apps/api/src/app/jobs/jobs.controller.ts
@@ -6,6 +6,14 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
 import { JobsService } from './jobs.service';
 import {
   CreateJobDto,
@@ -14,26 +22,48 @@ import {
   UpdateJobDto,
   createJobSchema,
   jobIdParamSchema,
+  jobSchema,
   updateJobSchema,
 } from '@job-tracker-lite-angular/schemas';
-import { ZodParam, ZodBody } from '@job-tracker-lite-angular/core-utils';
+import {
+  ZodParam,
+  ZodBody,
+  zodToApiSchema,
+} from '@job-tracker-lite-angular/core-utils';
 import {
   AuthGuard,
   Session,
   type UserSession,
 } from '@thallesp/nestjs-better-auth';
 
+@ApiTags('jobs')
+@ApiBearerAuth()
 @Controller('jobs')
 @UseGuards(AuthGuard)
 export class JobsController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Get()
+  @ApiOperation({
+    summary: 'List job applications',
+    description:
+      'Returns every job application owned by the authenticated user.',
+  })
+  @ApiOkResponse({
+    schema: { type: 'array', items: zodToApiSchema(jobSchema) },
+  })
   async findAll(@Session() session: UserSession): Promise<JobDto[]> {
     return this.jobsService.findAll(session.user.id);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a job application by id' })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(jobSchema) })
   async findOne(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -42,6 +72,16 @@ export class JobsController {
   }
 
   @Post()
+  @ApiOperation({
+    summary: 'Create a job application',
+    description:
+      'Creates a new job application owned by the authenticated user.',
+  })
+  @ApiBody({
+    description: 'Job application to create',
+    schema: zodToApiSchema(createJobSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(jobSchema) })
   async create(
     @Session() session: UserSession,
     @ZodBody(createJobSchema) createJobDto: CreateJobDto,
@@ -50,6 +90,21 @@ export class JobsController {
   }
 
   @Patch(':id/status')
+  @ApiOperation({
+    summary: 'Update a job application status',
+    description:
+      'Moves a job application to a different stage of the pipeline (e.g. applied, interviewing, offer, rejected).',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiBody({
+    description: 'New status for the job application',
+    schema: zodToApiSchema(updateJobSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(jobSchema) })
   async updateStatus(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -63,6 +118,20 @@ export class JobsController {
   }
 
   @Patch(':id')
+  @ApiOperation({
+    summary: 'Update a job application',
+    description: 'Partially updates the fields of an existing job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiBody({
+    description: 'Fields to update on the job application',
+    schema: zodToApiSchema(updateJobSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(jobSchema) })
   async update(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -72,6 +141,16 @@ export class JobsController {
   }
 
   @Delete(':id')
+  @ApiOperation({
+    summary: 'Delete a job application',
+    description:
+      'Permanently deletes a job application, along with its notes and contacts.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
   async delete(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,

--- a/apps/api/src/app/jobs/notes.controller.ts
+++ b/apps/api/src/app/jobs/notes.controller.ts
@@ -7,28 +7,57 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import {
   CreateNoteDto,
   NoteDto,
   UpdateNoteDto,
   createNoteSchema,
   jobIdParamSchema,
   noteIdParamSchema,
+  noteSchema,
   updateNoteSchema,
 } from '@job-tracker-lite-angular/schemas';
 import { JobsService } from './jobs.service';
-import { ZodBody, ZodParam } from '@job-tracker-lite-angular/core-utils';
+import {
+  ZodBody,
+  ZodParam,
+  zodToApiSchema,
+} from '@job-tracker-lite-angular/core-utils';
 import {
   AuthGuard,
   Session,
   type UserSession,
 } from '@thallesp/nestjs-better-auth';
 
+@ApiTags('notes')
+@ApiBearerAuth()
 @Controller('jobs/:id/notes')
 @UseGuards(AuthGuard)
 export class NotesController {
   constructor(private readonly jobsService: JobsService) {}
 
   @Delete(':noteId')
+  @ApiOperation({
+    summary: 'Delete a note',
+    description: 'Permanently deletes a note from a job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiParam({
+    name: 'noteId',
+    description: 'Note identifier (CUID2)',
+    schema: zodToApiSchema(noteIdParamSchema),
+  })
   async deleteNote(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -38,6 +67,25 @@ export class NotesController {
   }
 
   @Patch(':noteId')
+  @ApiOperation({
+    summary: 'Update a note',
+    description: 'Partially updates the title and/or body of an existing note.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiParam({
+    name: 'noteId',
+    description: 'Note identifier (CUID2)',
+    schema: zodToApiSchema(noteIdParamSchema),
+  })
+  @ApiBody({
+    description: 'Fields to update on the note',
+    schema: zodToApiSchema(updateNoteSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(noteSchema) })
   async updateNote(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -53,6 +101,20 @@ export class NotesController {
   }
 
   @Post()
+  @ApiOperation({
+    summary: 'Add a note to a job application',
+    description: 'Creates a new note linked to the given job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiBody({
+    description: 'Note to create',
+    schema: zodToApiSchema(createNoteSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(noteSchema) })
   async createNote(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,
@@ -66,6 +128,19 @@ export class NotesController {
   }
 
   @Get()
+  @ApiOperation({
+    summary: 'List notes for a job application',
+    description:
+      'Returns every note associated with the given job application.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'Job application identifier (CUID2)',
+    schema: zodToApiSchema(jobIdParamSchema),
+  })
+  @ApiOkResponse({
+    schema: { type: 'array', items: zodToApiSchema(noteSchema) },
+  })
   async findNotes(
     @Session() session: UserSession,
     @ZodParam('id', jobIdParamSchema) id: string,

--- a/apps/api/src/app/profile/profile.controller.ts
+++ b/apps/api/src/app/profile/profile.controller.ts
@@ -1,11 +1,19 @@
 import { Controller, Get, Patch, UseGuards } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { ProfileService } from './profile.service';
 import {
   updateUserProfileSchema,
   UserProfileDto,
   UpdateUserProfileDto,
+  userProfileSchema,
 } from '@job-tracker-lite-angular/schemas';
-import { ZodBody } from '@job-tracker-lite-angular/core-utils';
+import { ZodBody, zodToApiSchema } from '@job-tracker-lite-angular/core-utils';
 import {
   AuthGuard,
   AllowAnonymous,
@@ -13,6 +21,8 @@ import {
   type UserSession,
 } from '@thallesp/nestjs-better-auth';
 
+@ApiTags('profile')
+@ApiBearerAuth()
 @Controller('profile')
 @UseGuards(AuthGuard)
 export class ProfileController {
@@ -20,11 +30,27 @@ export class ProfileController {
 
   @Get()
   @AllowAnonymous()
+  @ApiOperation({
+    summary: 'Get the public profile',
+    description:
+      "Returns the authenticated user's profile, respecting per-section visibility settings.",
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(userProfileSchema) })
   async getProfile(@Session() session: UserSession): Promise<UserProfileDto> {
     return this.profileService.getProfile(session.user.id);
   }
 
   @Patch()
+  @ApiOperation({
+    summary: 'Update the profile',
+    description:
+      "Partially updates the fields of the authenticated user's profile.",
+  })
+  @ApiBody({
+    description: 'Fields to update on the profile',
+    schema: zodToApiSchema(updateUserProfileSchema),
+  })
+  @ApiOkResponse({ schema: zodToApiSchema(userProfileSchema) })
   async updateProfile(
     @Session() session: UserSession,
     @ZodBody(updateUserProfileSchema) updateProfileDto: UpdateUserProfileDto,

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { PrismaClientExceptionFilter } from '@job-tracker-lite-angular/prisma';
+import { setupSwagger } from './swagger.setup';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -28,11 +29,19 @@ async function bootstrap() {
       transform: true,
     }),
   );
+
+  const swaggerEnabled = setupSwagger(app, configService, globalPrefix);
+
   const port = Number(configService.get<string>('PORT') ?? '3000');
   await app.listen(port);
   Logger.log(
     `🚀 Application is running on: http://localhost:${port}/${globalPrefix}`,
   );
+  if (swaggerEnabled) {
+    Logger.log(
+      `📖 Swagger docs available at: http://localhost:${port}/${globalPrefix}/docs`,
+    );
+  }
 }
 
 bootstrap();

--- a/apps/api/src/swagger.setup.ts
+++ b/apps/api/src/swagger.setup.ts
@@ -1,0 +1,36 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+/**
+ * Swagger should only be enabled in non-production environments,
+ * so we can avoid exposing our API docs in production.
+ */
+function isDevEnvironment(configService: ConfigService): boolean {
+  return configService.get<string>('NODE_ENV') !== 'production';
+}
+
+/**
+ * Sets up Swagger UI/JSON at `${globalPrefix}/docs` when running outside of
+ * production. Returns whether it was set up, so the caller can log the URL.
+ */
+export function setupSwagger(
+  app: INestApplication,
+  configService: ConfigService,
+  globalPrefix: string,
+): boolean {
+  if (!isDevEnvironment(configService)) {
+    return false;
+  }
+
+  const config = new DocumentBuilder()
+    .setTitle('Job Tracker Lite API')
+    .setDescription('API documentation for the Job Tracker Lite backend')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup(`${globalPrefix}/docs`, app, document);
+
+  return true;
+}

--- a/libs/shared/core-utils/package.json
+++ b/libs/shared/core-utils/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@job-tracker-lite-angular/schemas": "0.0.1",
     "@nestjs/common": "^11.0.0",
+    "@nestjs/swagger": "^11.4.6",
     "express": "5.2.1",
     "tslib": "^2.3.0",
     "zod": "^4.4.3",

--- a/libs/shared/core-utils/src/index.ts
+++ b/libs/shared/core-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/decorators';
 export * from './lib/filters';
 export * from './lib/guards';
 export * from './lib/utils';
+export * from './lib/openapi';

--- a/libs/shared/core-utils/src/lib/openapi/index.ts
+++ b/libs/shared/core-utils/src/lib/openapi/index.ts
@@ -1,0 +1,1 @@
+export * from './zod-openapi.util';

--- a/libs/shared/core-utils/src/lib/openapi/zod-openapi.util.ts
+++ b/libs/shared/core-utils/src/lib/openapi/zod-openapi.util.ts
@@ -1,0 +1,13 @@
+import { z, ZodType } from 'zod';
+import type { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
+
+/**
+ * Converts a Zod schema into an OpenAPI 3.0 schema object, for use in
+ * Swagger decorators, e.g. `@ApiBody({ schema: zodToApiSchema(mySchema) })`.
+ */
+export function zodToApiSchema(schema: ZodType): SchemaObject {
+  return z.toJSONSchema(schema, {
+    target: 'openapi-3.0',
+    unrepresentable: 'any',
+  }) as unknown as SchemaObject;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@nestjs/core": "^11.0.0",
         "@nestjs/platform-express": "^11.0.0",
         "@nestjs/schedule": "^6.1.3",
+        "@nestjs/swagger": "^11.4.6",
         "@ng-icons/core": "^32.2.0",
         "@ng-icons/lucide": "^32.2.0",
         "@noble/hashes": "^2.2.0",
@@ -7405,7 +7406,6 @@
       "version": "0.16.0",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
       "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@microsoft/tsdoc-config": {
@@ -8489,6 +8489,26 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.28",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
@@ -8747,6 +8767,61 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+      "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "5.2.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.8"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@nestjs/terminus": {
@@ -13993,6 +14068,13 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@schematics/angular": {
       "version": "21.2.19",
@@ -36682,6 +36764,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@nestjs/core": "^11.0.0",
     "@nestjs/platform-express": "^11.0.0",
     "@nestjs/schedule": "^6.1.3",
+    "@nestjs/swagger": "^11.4.6",
     "@ng-icons/core": "^32.2.0",
     "@ng-icons/lucide": "^32.2.0",
     "@noble/hashes": "^2.2.0",


### PR DESCRIPTION
This pull request adds comprehensive OpenAPI/Swagger documentation to the API controllers for accounts, jobs, contacts, and health checks. This includes endpoint summaries, descriptions, request/response schemas, and security annotations, making the API self-documenting and much easier to consume for frontend developers and third-party integrators.

The most important changes are:

### API Documentation Enhancements

* Added `@ApiTags`, `@ApiOperation`, `@ApiBody`, `@ApiParam`, `@ApiOkResponse`, and `@ApiBearerAuth` decorators throughout `account.controller.ts`, `jobs.controller.ts`, `contacts.controller.ts`, and `healthcheck.controller.ts` to provide detailed endpoint documentation, including operation summaries, descriptions, parameter details, and request/response schemas derived from Zod schemas. [[1]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R3-R13) [[2]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24L13-R24) [[3]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R34-R47) [[4]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R56-R66) [[5]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R81-R99) [[6]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R114-R127) [[7]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R138-R147) [[8]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R161-R179) [[9]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R194-R200) [[10]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R209-R242) [[11]](diffhunk://#diff-8fda1752d57541da75a2320671722153812e9abec8c40db3598a7446e309e2edR3-R7) [[12]](diffhunk://#diff-8fda1752d57541da75a2320671722153812e9abec8c40db3598a7446e309e2edR16-R20) [[13]](diffhunk://#diff-8fda1752d57541da75a2320671722153812e9abec8c40db3598a7446e309e2edR29-R45) [[14]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470R9-R19) [[15]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470L20-R60) [[16]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470R69-R83) [[17]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470R97-R115) [[18]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470R131-R144) [[19]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R9-R16) [[20]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R25-R66) [[21]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R75-R84) [[22]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R93-R107) [[23]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R121-R134) [[24]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R144-R153)

### Improved Schema Integration

* Introduced `zodToApiSchema` to automatically generate OpenAPI schemas from existing Zod validation schemas, ensuring that the documentation always matches the actual validation logic. [[1]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24L13-R24) [[2]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470L20-R60) [[3]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R25-R66)

### Security and Tagging

* Added `@ApiBearerAuth` to all endpoints requiring authentication and `@ApiTags` to organize endpoints by resource in the Swagger UI. [[1]](diffhunk://#diff-f79b3f8938ff70fc5136fb6dcac18f14659c9f9cace61b7637079e75a948ef24R34-R47) [[2]](diffhunk://#diff-78739e9d4ae75e08bc86b101c1d6d48f4ff4b937bd1d2b865b58525e2bb8f470L20-R60) [[3]](diffhunk://#diff-8dc83195fcbcf03a67f2bdbc7335f91d8cfd0b7f270b145ee3c0d80a6ba92396R25-R66) [[4]](diffhunk://#diff-8fda1752d57541da75a2320671722153812e9abec8c40db3598a7446e309e2edR3-R7)

These changes significantly improve the developer experience by making the API self-describing and easier to use, while ensuring the documentation stays in sync with the code.

Closes #117 