### PR TITLE
fix(profile): import PrismaModule and update testConnection return type

### DIFF
--- a/apps/api/src/app/profile/profile.module.ts
+++ b/apps/api/src/app/profile/profile.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
+import { PrismaModule } from '@job-tracker-lite-angular/prisma';
 import { ProfileController } from './profile.controller';
 import { ProfileService } from './profile.service';
 
 @Module({
+  imports: [PrismaModule],
   controllers: [ProfileController],
   providers: [ProfileService],
 })

--- a/libs/shared/prisma/src/lib/prisma.service.ts
+++ b/libs/shared/prisma/src/lib/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, User } from '@prisma/client';
 import { PrismaPg } from '@prisma/adapter-pg';
 
 @Injectable()
@@ -25,7 +25,7 @@ export class PrismaService
     await this.$disconnect();
   }
 
-  async testConnection() {
+  async testConnection(): Promise<User[]> {
     return await this.user.findMany();
   }
 }

--- a/libs/shared/testing/package.json
+++ b/libs/shared/testing/package.json
@@ -10,6 +10,7 @@
     "@job-tracker-lite-angular/schemas": "0.0.1",
     "@angular/core": "~21.2.0",
     "@ng-icons/core": "^32.2.0",
-    "@ng-icons/lucide": "^32.2.0"
+    "@ng-icons/lucide": "^32.2.0",
+    "@nestjs/common": "^11.0.0"
   }
 }

--- a/libs/shared/testing/src/lib/mocks/thallesp-nestjs-better-auth.mock.ts
+++ b/libs/shared/testing/src/lib/mocks/thallesp-nestjs-better-auth.mock.ts
@@ -1,3 +1,4 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 import type { AuthSessionDto } from '@job-tracker-lite-angular/schemas';
 
 export class AuthGuard {}
@@ -16,11 +17,12 @@ export const AllowAnonymous = noopDecorator;
 export const OptionalAuth = noopDecorator;
 export const Public = noopDecorator;
 
-export const Session = () => {
-  return (target: object, key: string | symbol, index: number) => {
-    // empty
-  };
-};
+export const Session = createParamDecorator(
+  (_data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.session;
+  },
+);
 
 export type UserSession = NonNullable<AuthSessionDto>;
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes related to Prisma integration and authentication testing utilities. The main updates include registering the `PrismaModule` in the profile module, enhancing the `PrismaService` for better type safety, and updating the Session decorator mock for more realistic behavior in tests.

**Prisma integration improvements:**

* Registered the `PrismaModule` in the `ProfileModule` by adding it to the `imports` array in `profile.module.ts`, ensuring Prisma is properly injected and available for dependency injection.
* Updated the `testConnection` method in `PrismaService` to return a typed array of `User` objects, improving type safety and clarity.
* Imported the `User` type from `@prisma/client` in `prisma.service.ts` to support the improved typing in `testConnection`.

**Authentication testing utilities:**

* Changed the `Session` decorator mock in `thallesp-nestjs-better-auth.mock.ts` to use NestJS's `createParamDecorator`, making it return the request's session object and more closely mimic real behavior.
* Added necessary imports for `createParamDecorator` and `ExecutionContext` to support the updated `Session` decorator.