### PR TITLE
fix(healthcheck): improve health checks to avoid hanging on timeouts

### DIFF
--- a/apps/api/src/app/healthcheck/healthcheck.service.spec.ts
+++ b/apps/api/src/app/healthcheck/healthcheck.service.spec.ts
@@ -57,7 +57,11 @@ describe('HealthService', () => {
   it('checks only the database for readiness', async () => {
     await service.checkReadiness();
 
-    expect(dbPingCheck).toHaveBeenCalledWith('database', expect.anything());
+    expect(dbPingCheck).toHaveBeenCalledWith(
+      'database',
+      expect.anything(),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
     expect(uptimeIsHealthy).not.toHaveBeenCalled();
     expect(redisIsHealthy).not.toHaveBeenCalled();
   });
@@ -65,7 +69,11 @@ describe('HealthService', () => {
   it('checks database, uptime and redis for the detailed report', async () => {
     await service.checkDetailed();
 
-    expect(dbPingCheck).toHaveBeenCalledWith('database', expect.anything());
+    expect(dbPingCheck).toHaveBeenCalledWith(
+      'database',
+      expect.anything(),
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
     expect(uptimeIsHealthy).toHaveBeenCalledWith('server');
     expect(redisIsHealthy).toHaveBeenCalledWith('redis');
   });

--- a/apps/api/src/app/healthcheck/healthcheck.service.ts
+++ b/apps/api/src/app/healthcheck/healthcheck.service.ts
@@ -14,6 +14,10 @@ export class HealthService {
     private readonly prisma: PrismaService,
   ) {}
 
+  // Bound the database ping so a downed/unreachable DB reports "down" quickly
+  // instead of stalling the request while the driver waits on a dead socket.
+  private readonly dbPingTimeoutMs = 2000;
+
   /**
    * Check if the service is alive and responding. Only checks the uptime of this instance.
    */
@@ -26,7 +30,10 @@ export class HealthService {
    */
   checkReadiness() {
     return this.health.check([
-      () => this.db.pingCheck('database', this.prisma),
+      () =>
+        this.db.pingCheck('database', this.prisma, {
+          timeout: this.dbPingTimeoutMs,
+        }),
     ]);
   }
 
@@ -38,7 +45,10 @@ export class HealthService {
    */
   checkDetailed() {
     return this.health.check([
-      () => this.db.pingCheck('database', this.prisma),
+      () =>
+        this.db.pingCheck('database', this.prisma, {
+          timeout: this.dbPingTimeoutMs,
+        }),
       () => this.uptime.isHealthy('server'),
       () => this.redis.isHealthy('redis'),
     ]);

--- a/apps/api/src/app/healthcheck/redis.health.spec.ts
+++ b/apps/api/src/app/healthcheck/redis.health.spec.ts
@@ -97,4 +97,42 @@ describe('RedisHealthIndicator', () => {
 
     jest.useRealTimers();
   });
+
+  it('should report down instead of hanging when a connected client never answers ping', async () => {
+    jest.useFakeTimers();
+
+    const healthIndicatorService = {
+      check: jest.fn(() => ({ up: upMock, down: downMock })),
+    };
+    // Connection is established (client resolves) but the ping is parked in
+    // ioredis's offline queue and never settles - mirrors Redis dropping after
+    // the app has already connected.
+    const emailQueue = {
+      client: Promise.resolve({ ping: () => new Promise(() => undefined) }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RedisHealthIndicator,
+        { provide: HealthIndicatorService, useValue: healthIndicatorService },
+        { provide: getQueueToken(EMAIL_QUEUE), useValue: emailQueue },
+      ],
+    }).compile();
+    const indicatorUnderTest =
+      module.get<RedisHealthIndicator>(RedisHealthIndicator);
+
+    const resultPromise = indicatorUnderTest.isHealthy('redis');
+    await jest.advanceTimersByTimeAsync(2000);
+    const result = await resultPromise;
+
+    expect(downMock).toHaveBeenCalledWith({
+      message: 'Redis connection timed out',
+    });
+    expect(result).toEqual({
+      status: 'down',
+      message: 'Redis connection timed out',
+    });
+
+    jest.useRealTimers();
+  });
 });

--- a/apps/api/src/app/healthcheck/redis.health.ts
+++ b/apps/api/src/app/healthcheck/redis.health.ts
@@ -17,11 +17,7 @@ export class RedisHealthIndicator {
     const indicator = this.healthIndicatorService.check(key);
 
     try {
-      const client = (await Promise.race([
-        this.emailQueue.client,
-        this.connectionTimeout(),
-      ])) as unknown as Redis;
-      await client.ping();
+      await Promise.race([this.ping(), this.connectionTimeout()]);
       return indicator.up();
     } catch (error) {
       return indicator.down({
@@ -30,9 +26,18 @@ export class RedisHealthIndicator {
     }
   }
 
-  // ioredis retries a broken connection forever by default, so awaiting
-  // Queue.client never settles while Redis is unreachable. Bound the wait
-  // so the health check reports "down" instead of hanging the request.
+  private async ping(): Promise<void> {
+    const client = (await this.emailQueue.client) as unknown as Redis;
+    await client.ping();
+  }
+
+  // Two ways a dead Redis can wedge this check, both bounded by the timeout:
+  //  - ioredis retries a broken connection forever, so awaiting Queue.client
+  //    never settles when Redis was never reachable.
+  //  - if the connection was established and then dropped, `client.ping()` is
+  //    parked in ioredis's offline command queue and never settles either.
+  // Racing the whole ping against this timeout reports "down" instead of
+  // hanging the request in either case.
   private connectionTimeout(): Promise<never> {
     return new Promise((_, reject) =>
       setTimeout(() => reject(new Error('Redis connection timed out')), 2000),

--- a/apps/frontend/src/app/navigation/sidenav/sidenav.component.ts
+++ b/apps/frontend/src/app/navigation/sidenav/sidenav.component.ts
@@ -78,7 +78,10 @@ export class SidenavComponent {
     'navigation.appTitleTooltip',
   );
 
-  private readonly healthResource = this.healthDataAccess.healthResource;
+  // The navbar reflects readiness (can we serve traffic?), not the full
+  // detailed report - so a non-critical dependency like redis being down
+  // does not surface as a warning here. The /status page shows the details.
+  private readonly healthResource = this.healthDataAccess.readinessResource;
 
   private readonly health = computed(() =>
     selectHealthValue(this.healthResource),

--- a/apps/frontend/src/app/status/status.component.html
+++ b/apps/frontend/src/app/status/status.component.html
@@ -21,10 +21,10 @@
               <span
                 hlmBadge
                 class="text-white"
-                [class.bg-green-500]="healthData.status === 'ok'"
-                [class.bg-red-500]="healthData.status === 'error'"
+                [class.bg-green-500]="apiStatus() === 'ok'"
+                [class.bg-red-500]="apiStatus() === 'error'"
               >
-                {{ healthData.status.toUpperCase() }}
+                {{ apiStatus().toUpperCase() }}
               </span>
             </div>
           </hlm-card>

--- a/apps/frontend/src/app/status/status.component.spec.ts
+++ b/apps/frontend/src/app/status/status.component.spec.ts
@@ -8,6 +8,7 @@ import {
   createHealthDataAccessMock,
   degradedHealth,
   healthFixture,
+  redisDownHealth,
 } from '@job-tracker-lite-angular/testing';
 import { describe, expect, it } from 'vitest';
 import { StatusComponent } from './status.component';
@@ -87,6 +88,23 @@ describe('StatusComponent', () => {
 
     expect(await harness.getApiStatus()).toContain('ERROR');
     expect(await harness.getDatabaseStatus()).toContain('DOWN');
+  });
+
+  it('keeps the API status OK when only redis is down', async () => {
+    const { harness } = await setup({
+      health: null,
+      hasValue: false,
+      error: new HttpErrorResponse({
+        status: 503,
+        error: redisDownHealth,
+      }),
+    });
+
+    // The app can still serve traffic, so the API reads OK even though the
+    // overall report status is "error" and the queue card shows DOWN.
+    expect(await harness.getApiStatus()).toContain('OK');
+    expect(await harness.getDatabaseStatus()).toContain('UP');
+    expect(await harness.getQueueStatus()).toContain('DOWN');
   });
 
   it('should show an offline fallback when the backend is unreachable', async () => {

--- a/apps/frontend/src/app/status/status.component.ts
+++ b/apps/frontend/src/app/status/status.component.ts
@@ -46,6 +46,20 @@ export class StatusComponent {
     selectHealthValue(this.healthResource),
   );
 
+  protected readonly apiStatus = computed<'ok' | 'error'>(() => {
+    const health = this.health();
+    if (!health) {
+      return 'error';
+    }
+
+    const dbStatus =
+      health.info.database?.status ?? health.error.database?.status;
+    const serverStatus =
+      health.info.server?.status ?? health.error.server?.status;
+
+    return dbStatus === 'up' && serverStatus === 'up' ? 'ok' : 'error';
+  });
+
   protected readonly isUnreachable = computed(() =>
     isHealthUnreachable(this.healthResource, this.health()),
   );

--- a/libs/frontend/src/lib/data-access/health.data-access.spec.ts
+++ b/libs/frontend/src/lib/data-access/health.data-access.spec.ts
@@ -28,6 +28,14 @@ describe('HealthDataAccessService', () => {
     httpMock.verify();
   });
 
+  const okBody = { status: 'ok', info: {}, error: {}, details: {} } as const;
+
+  // Both resources load eagerly, so drain the sibling request the test under
+  // inspection isn't asserting on to keep httpMock.verify() happy.
+  function drainRemaining(): void {
+    httpMock.match(() => true).forEach((req) => req.flush(okBody));
+  }
+
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
@@ -39,11 +47,20 @@ describe('HealthDataAccessService', () => {
 
     const req = httpMock.expectOne('/api/health/detailed');
     expect(req.request.method).toBe('GET');
-    req.flush({
-      status: 'ok',
-      info: {},
-      error: {},
-      details: {},
-    });
+    req.flush(okBody);
+
+    drainRemaining();
+  });
+
+  it('should request the readiness health endpoint', () => {
+    service.readinessResource.reload();
+
+    TestBed.flushEffects();
+
+    const req = httpMock.expectOne('/api/health/ready');
+    expect(req.request.method).toBe('GET');
+    req.flush(okBody);
+
+    drainRemaining();
   });
 });

--- a/libs/frontend/src/lib/data-access/health.data-access.ts
+++ b/libs/frontend/src/lib/data-access/health.data-access.ts
@@ -6,8 +6,16 @@ import { HealthResponseDto } from '@job-tracker-lite-angular/schemas';
   providedIn: 'root',
 })
 export class HealthDataAccessService {
+  // Full report (database + server + redis) for the manual /status dashboard.
   healthResource = httpResource<HealthResponseDto>(
     () => `/api/health/detailed`,
+  );
+
+  // Readiness probe (dependencies required to serve traffic - the database).
+  // Drives the navbar indicator: redis being down must not flag the app as
+  // unhealthy there, since it isn't required to serve requests.
+  readinessResource = httpResource<HealthResponseDto>(
+    () => `/api/health/ready`,
   );
 }
 

--- a/libs/shared/schemas/src/lib/schemas/health.schema.ts
+++ b/libs/shared/schemas/src/lib/schemas/health.schema.ts
@@ -4,6 +4,7 @@ export const healthIndicatorSchema = z.object({
   status: z.enum(['up', 'down']),
   uptime: z.string().optional(),
   timestamp: z.string().optional(),
+  message: z.string().optional(),
 });
 export type HealthIndicator = z.infer<typeof healthIndicatorSchema>;
 

--- a/libs/shared/testing/src/lib/fixtures/health.fixtures.ts
+++ b/libs/shared/testing/src/lib/fixtures/health.fixtures.ts
@@ -35,6 +35,30 @@ export const healthFixture: HealthResponseDto = {
   },
 };
 
+export const redisDownHealth: HealthResponseDto = {
+  status: 'error',
+  info: {
+    database: { status: 'up' },
+    server: {
+      status: 'up',
+      uptime: '1051',
+      timestamp: '2026-07-23T14:21:25.528Z',
+    },
+  },
+  error: {
+    redis: { status: 'down', message: 'Redis connection timed out' },
+  },
+  details: {
+    database: { status: 'up' },
+    server: {
+      status: 'up',
+      uptime: '1051',
+      timestamp: '2026-07-23T14:21:25.528Z',
+    },
+    redis: { status: 'down', message: 'Redis connection timed out' },
+  },
+};
+
 export const degradedHealth: HealthResponseDto = {
   status: 'error',
   info: {

--- a/libs/shared/testing/src/lib/mocks/data-access.mock.ts
+++ b/libs/shared/testing/src/lib/mocks/data-access.mock.ts
@@ -22,7 +22,7 @@ export function createHealthDataAccessMock(
   const isLoading = options.isLoading ?? false;
   const hasValue = options.hasValue ?? health !== null;
 
-  const healthResource: HealthResourceState = {
+  const resourceState: HealthResourceState = {
     value: () => health,
     isLoading: () => isLoading,
     reload: () => undefined,
@@ -30,8 +30,11 @@ export function createHealthDataAccessMock(
     hasValue: () => hasValue,
   };
 
+  // Both resources share the same options-driven state: consumers pick whichever
+  // one they depend on (the navbar uses readiness, the status page detailed).
   return {
-    healthResource,
+    healthResource: resourceState,
+    readinessResource: resourceState,
   };
 }
 


### PR DESCRIPTION
This pull request improves the application's health check system to better distinguish between critical and non-critical dependencies, ensuring that the app only reports as "down" in the UI when required services (like the database) are unavailable. Redis outages no longer cause the main API status indicator to show an error, but are still visible in the detailed status report. The changes also introduce stricter timeouts for health checks to avoid hanging requests when dependencies are unreachable.

**Backend health check improvements:**

* Added a 2-second timeout to database and Redis health checks to ensure the app quickly reports "down" if these services are unresponsive, preventing requests from hanging indefinitely. (`healthcheck.service.ts`, `redis.health.ts`) [[1]](diffhunk://#diff-1c531833adb7ff136a09e099a9f2ce7f383b0cce56a4a5182ffc488a1d3b45faR17-R20) [[2]](diffhunk://#diff-1c531833adb7ff136a09e099a9f2ce7f383b0cce56a4a5182ffc488a1d3b45faL29-R36) [[3]](diffhunk://#diff-1c531833adb7ff136a09e099a9f2ce7f383b0cce56a4a5182ffc488a1d3b45faL41-R51) [[4]](diffhunk://#diff-13e585cf3ec0dfe62fe798c0c0dd5b252edb938deb7340118f2e3859a29ebc34L20-R20) [[5]](diffhunk://#diff-13e585cf3ec0dfe62fe798c0c0dd5b252edb938deb7340118f2e3859a29ebc34L33-R40)
* Refined Redis health check logic to handle cases where the Redis client is connected but stops responding, ensuring the health check fails fast with a clear error message. (`redis.health.ts`, `redis.health.spec.ts`) [[1]](diffhunk://#diff-13e585cf3ec0dfe62fe798c0c0dd5b252edb938deb7340118f2e3859a29ebc34L20-R20) [[2]](diffhunk://#diff-13e585cf3ec0dfe62fe798c0c0dd5b252edb938deb7340118f2e3859a29ebc34L33-R40) [[3]](diffhunk://#diff-e1fc25d85778598133be258d434a64dfe75e0c6bd5bc41a748a9e0f94b670cf5R100-R137)

**Frontend health status reporting:**

* Introduced a separate `readinessResource` for the navbar, which only reflects the status of critical dependencies (database and server), so Redis outages do not incorrectly flag the API as down in the main UI. (`health.data-access.ts`, `sidenav.component.ts`, `status.component.ts`, `status.component.html`) [[1]](diffhunk://#diff-f5d6bd5ffa136e7cddffa3dfb2ceac7a2c87abc3ae1e6c0e5e0d2a08c13149b7R9-R19) [[2]](diffhunk://#diff-a99f7132f418a1e6b435a3d8dc873e3ffb5782fffce083551e466e0a8d2f4fe7L81-R84) [[3]](diffhunk://#diff-cd78728c205dc050e3b951bce9da7710082184c43cefbefc4227cef5c87e1fffR49-R62) [[4]](diffhunk://#diff-2f0c6eb48181b477c31779da38ebda7580300f605e1bc472611cd9466a63dc9cL24-R27)
* Updated the `/status` dashboard and tests to show detailed dependency status, ensuring Redis outages are visible there but do not affect the overall API status unless critical services are down. (`status.component.spec.ts`, `health.fixtures.ts`, `data-access.mock.ts`) [[1]](diffhunk://#diff-2b452dccc857fe9b1b4c9b4d5021d63a90b90eeba04c34515080382a2e76bc7aR11) [[2]](diffhunk://#diff-2b452dccc857fe9b1b4c9b4d5021d63a90b90eeba04c34515080382a2e76bc7aR93-R109) [[3]](diffhunk://#diff-c39e440f72bd08097ef0fb806d21abee5d8eeeb2d27fedf606c2fd3673817d0cR38-R61) [[4]](diffhunk://#diff-c0027cdd5a8ecfef0c65a5e56607b6e936b74c3e06d973ab36d2d55209e5cf22L25-R37)

**Testing and schema updates:**

* Added tests to verify that Redis outages do not affect the main API status indicator, and updated the health schema to include error messages for better diagnostics. (`healthcheck.service.spec.ts`, `health.data-access.spec.ts`, `health.schema.ts`) [[1]](diffhunk://#diff-b08e229f5d817c285457ad5b5a2dfce412a6c5f5adbfe7a479cdb42d1cc28471L60-R76) [[2]](diffhunk://#diff-8b9dc3dba7c972f1a2a9fb4c422febadbfe0fa56a97e29ec705ced9af6565622R31-R38) [[3]](diffhunk://#diff-8b9dc3dba7c972f1a2a9fb4c422febadbfe0fa56a97e29ec705ced9af6565622L42-R64) [[4]](diffhunk://#diff-87870da2c433e04d3c6f092ae7d6b472e92ff9010baecd58983c951f8c832c9aR7)

These changes make the health check system more robust and provide clearer, more accurate status reporting for both users and developers.

closes #135 