### PR TITLE
feat(email): add support for mailpit and resend email providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ DB_NAME=<your_db_name>
 # prisma db url
 DATABASE_URL=<your_database_url>
 
+TEST_DB_NAME=<your_test_db_name>
+TEST_DB_PORT=<your_test_db_port>
+TEST_DATABASE_URL=<your_test_database_url>
+
 # App origins
 PORT=<your_port>
 NODE_ENV=<your_node_env>
@@ -39,12 +43,14 @@ RESEND_API_KEY=<your_resend_api_key>
 MAILPIT_HOST=<your_mailpit_host>
 MAILPIT_PORT=<your_mailpit_port>
 
-# queue
-REDIS_PASSWORD = <your_redis_password>
-QUEUE_DASHBOARD_ROUTE = <your_queue_dashboard_route>
-REDIS_HOST = <your_redis_host>
-REDIS_PORT = <your_redis_port>
-REDIS_URL = <your_redis_url>
+# Queue Dashboard
 ENABLE_QUEUE_DASHBOARD = <true_or_false>
 QUEUE_DASHBOARD_USER = <your_queue_dashboard_user>
 QUEUE_DASHBOARD_PASSWORD = <your_queue_dashboard_password>
+QUEUE_DASHBOARD_ROUTE = <your_queue_dashboard_route>
+
+# queue
+REDIS_PASSWORD = <your_redis_password>
+REDIS_HOST = <your_redis_host>
+REDIS_PORT = <your_redis_port>
+REDIS_URL = <your_redis_url>

--- a/.env.example
+++ b/.env.example
@@ -21,14 +21,23 @@ EMAIL_RESTORE_EXPIRES_IN_SECONDS = <your_email_restore_expires_in_seconds>
 ACCOUNT_DELETION_GRACE_PERIOD_DAYS = <your_account_deletion_grace_period_days>
 ACCOUNT_DELETION_CONFIRM_EXPIRES_IN_SECONDS = <your_account_deletion_confirm_expires_in_seconds>
 
-# SMTP for password reset emails
+# Email provider selection: mailtrap | resend | mailpit
 EMAIL_PROVIDER=<your_email_provider>
+SMTP_FROM=<your_email_from>
+
+# SMTP (used when EMAIL_PROVIDER=mailtrap)
 SMTP_HOST=<your_smtp_host>
 SMTP_PORT=<your_smtp_port>
 SMTP_SECURE=<true_or_false>
 SMTP_USER=<your_smtp_user>
 SMTP_PASS=<your_smtp_password>
-SMTP_FROM=<your_email_from>
+
+# Resend (used when EMAIL_PROVIDER=resend) - production
+RESEND_API_KEY=<your_resend_api_key>
+
+# Mailpit (used when EMAIL_PROVIDER=mailpit) - dev/test SMTP catch-all
+MAILPIT_HOST=<your_mailpit_host>
+MAILPIT_PORT=<your_mailpit_port>
 
 # queue
 REDIS_PASSWORD = <your_redis_password>

--- a/apps/api/src/app/email/email.config.spec.ts
+++ b/apps/api/src/app/email/email.config.spec.ts
@@ -84,6 +84,17 @@ describe('email.config', () => {
 
       expect(config.mailpit).toEqual({ host: 'mailpit.local', port: 2025 });
     });
+
+    it('should not require mailtrap SMTP values for an unrecognized provider', () => {
+      const configService = buildConfigService({ EMAIL_PROVIDER: 'sendgrid' });
+
+      const config = getEmailConfig(configService);
+
+      expect(config).toEqual({
+        provider: 'sendgrid',
+        from: 'no-reply@example.com',
+      });
+    });
   });
 
   describe('getMailerOptions', () => {

--- a/apps/api/src/app/email/email.config.spec.ts
+++ b/apps/api/src/app/email/email.config.spec.ts
@@ -1,0 +1,142 @@
+import { ConfigService } from '@nestjs/config';
+import { getEmailConfig, getMailerOptions } from './email.config';
+
+describe('email.config', () => {
+  const buildConfigService = (
+    values: Record<string, string | undefined>,
+  ): ConfigService =>
+    ({
+      get: jest.fn((key: string) => values[key]),
+    }) as unknown as ConfigService;
+
+  describe('getEmailConfig', () => {
+    it('should default to the mailtrap provider when EMAIL_PROVIDER is unset', () => {
+      const configService = buildConfigService({
+        SMTP_HOST: 'smtp.mailtrap.io',
+        SMTP_USER: 'user',
+        SMTP_PASS: 'pass',
+      });
+
+      const config = getEmailConfig(configService);
+
+      expect(config.provider).toBe('mailtrap');
+      expect(config.mailtrap).toEqual({
+        host: 'smtp.mailtrap.io',
+        port: 2525,
+        secure: false,
+        user: 'user',
+        pass: 'pass',
+      });
+    });
+
+    it('should throw when a required mailtrap value is missing', () => {
+      const configService = buildConfigService({ EMAIL_PROVIDER: 'mailtrap' });
+
+      expect(() => getEmailConfig(configService)).toThrow(
+        'Missing required email configuration: SMTP_HOST',
+      );
+    });
+
+    it('should build resend config without requiring SMTP values', () => {
+      const configService = buildConfigService({
+        EMAIL_PROVIDER: 'resend',
+        RESEND_API_KEY: 'resend-key',
+        SMTP_FROM: 'from@example.com',
+      });
+
+      const config = getEmailConfig(configService);
+
+      expect(config).toEqual({
+        provider: 'resend',
+        from: 'from@example.com',
+        resend: { apiKey: 'resend-key' },
+      });
+    });
+
+    it('should throw when RESEND_API_KEY is missing for the resend provider', () => {
+      const configService = buildConfigService({ EMAIL_PROVIDER: 'resend' });
+
+      expect(() => getEmailConfig(configService)).toThrow(
+        'Missing required email configuration: RESEND_API_KEY',
+      );
+    });
+
+    it('should build mailpit config with sensible defaults', () => {
+      const configService = buildConfigService({ EMAIL_PROVIDER: 'mailpit' });
+
+      const config = getEmailConfig(configService);
+
+      expect(config).toEqual({
+        provider: 'mailpit',
+        from: 'no-reply@example.com',
+        mailpit: { host: 'localhost', port: 1025 },
+      });
+    });
+
+    it('should honor custom mailpit host/port', () => {
+      const configService = buildConfigService({
+        EMAIL_PROVIDER: 'mailpit',
+        MAILPIT_HOST: 'mailpit.local',
+        MAILPIT_PORT: '2025',
+      });
+
+      const config = getEmailConfig(configService);
+
+      expect(config.mailpit).toEqual({ host: 'mailpit.local', port: 2025 });
+    });
+  });
+
+  describe('getMailerOptions', () => {
+    it('should build an SMTP transport for mailtrap', () => {
+      const configService = buildConfigService({
+        EMAIL_PROVIDER: 'mailtrap',
+        SMTP_HOST: 'smtp.mailtrap.io',
+        SMTP_PORT: '2525',
+        SMTP_USER: 'user',
+        SMTP_PASS: 'pass',
+        SMTP_FROM: 'from@example.com',
+      });
+
+      const options = getMailerOptions(configService);
+
+      expect(options).toEqual({
+        transport: {
+          host: 'smtp.mailtrap.io',
+          port: 2525,
+          secure: false,
+          auth: { user: 'user', pass: 'pass' },
+        },
+        defaults: { from: 'from@example.com' },
+      });
+    });
+
+    it('should build an SMTP transport for mailpit without auth', () => {
+      const configService = buildConfigService({
+        EMAIL_PROVIDER: 'mailpit',
+        SMTP_FROM: 'from@example.com',
+      });
+
+      const options = getMailerOptions(configService);
+
+      expect(options).toEqual({
+        transport: { host: 'localhost', port: 1025, secure: false },
+        defaults: { from: 'from@example.com' },
+      });
+    });
+
+    it('should fall back to a jsonTransport for non-SMTP providers like resend', () => {
+      const configService = buildConfigService({
+        EMAIL_PROVIDER: 'resend',
+        RESEND_API_KEY: 'resend-key',
+        SMTP_FROM: 'from@example.com',
+      });
+
+      const options = getMailerOptions(configService);
+
+      expect(options).toEqual({
+        transport: { jsonTransport: true },
+        defaults: { from: 'from@example.com' },
+      });
+    });
+  });
+});

--- a/apps/api/src/app/email/email.config.ts
+++ b/apps/api/src/app/email/email.config.ts
@@ -60,7 +60,6 @@ export function getEmailConfig(configService: ConfigService): EmailConfig {
         },
       };
     case 'mailtrap':
-    default:
       return {
         provider,
         from,
@@ -72,6 +71,9 @@ export function getEmailConfig(configService: ConfigService): EmailConfig {
           pass: getRequiredValue(configService, 'SMTP_PASS'),
         },
       };
+    default:
+      // Let email-provider.factory.ts handle unrecognized provider validation.
+      return { provider, from };
   }
 }
 

--- a/apps/api/src/app/email/email.config.ts
+++ b/apps/api/src/app/email/email.config.ts
@@ -9,10 +9,21 @@ interface MailtrapConfig {
   pass: string;
 }
 
+interface ResendConfig {
+  apiKey: string;
+}
+
+interface MailpitConfig {
+  host: string;
+  port: number;
+}
+
 export interface EmailConfig {
   provider: string;
   from: string;
-  mailtrap: MailtrapConfig;
+  mailtrap?: MailtrapConfig;
+  resend?: ResendConfig;
+  mailpit?: MailpitConfig;
 }
 
 function getRequiredValue(configService: ConfigService, key: string): string {
@@ -26,33 +37,83 @@ function getRequiredValue(configService: ConfigService, key: string): string {
 }
 
 export function getEmailConfig(configService: ConfigService): EmailConfig {
-  return {
-    provider:
-      (configService.get<string>('EMAIL_PROVIDER') as string) ?? 'mailtrap',
-    from: configService.get<string>('SMTP_FROM') ?? 'no-reply@example.com',
-    mailtrap: {
-      host: getRequiredValue(configService, 'SMTP_HOST'),
-      port: Number(configService.get<string>('SMTP_PORT') ?? '2525'),
-      secure: configService.get<string>('SMTP_SECURE') === 'true',
-      user: getRequiredValue(configService, 'SMTP_USER'),
-      pass: getRequiredValue(configService, 'SMTP_PASS'),
-    },
-  };
+  const provider =
+    (configService.get<string>('EMAIL_PROVIDER') as string) ?? 'mailtrap';
+  const from = configService.get<string>('SMTP_FROM') ?? 'no-reply@example.com';
+
+  switch (provider) {
+    case 'resend':
+      return {
+        provider,
+        from,
+        resend: {
+          apiKey: getRequiredValue(configService, 'RESEND_API_KEY'),
+        },
+      };
+    case 'mailpit':
+      return {
+        provider,
+        from,
+        mailpit: {
+          host: configService.get<string>('MAILPIT_HOST') ?? 'localhost',
+          port: Number(configService.get<string>('MAILPIT_PORT') ?? '1025'),
+        },
+      };
+    case 'mailtrap':
+    default:
+      return {
+        provider,
+        from,
+        mailtrap: {
+          host: getRequiredValue(configService, 'SMTP_HOST'),
+          port: Number(configService.get<string>('SMTP_PORT') ?? '2525'),
+          secure: configService.get<string>('SMTP_SECURE') === 'true',
+          user: getRequiredValue(configService, 'SMTP_USER'),
+          pass: getRequiredValue(configService, 'SMTP_PASS'),
+        },
+      };
+  }
 }
 
 export function getMailerOptions(configService: ConfigService): MailerOptions {
   const emailConfig = getEmailConfig(configService);
 
-  return {
-    transport: {
-      host: emailConfig.mailtrap.host,
-      port: emailConfig.mailtrap.port,
-      secure: emailConfig.mailtrap.secure,
-      auth: {
-        user: emailConfig.mailtrap.user,
-        pass: emailConfig.mailtrap.pass,
+  if (emailConfig.mailpit) {
+    return {
+      transport: {
+        host: emailConfig.mailpit.host,
+        port: emailConfig.mailpit.port,
+        secure: false,
       },
-    },
+      defaults: {
+        from: emailConfig.from,
+      },
+    };
+  }
+
+  if (emailConfig.mailtrap) {
+    return {
+      transport: {
+        host: emailConfig.mailtrap.host,
+        port: emailConfig.mailtrap.port,
+        secure: emailConfig.mailtrap.secure,
+        auth: {
+          user: emailConfig.mailtrap.user,
+          pass: emailConfig.mailtrap.pass,
+        },
+      },
+      defaults: {
+        from: emailConfig.from,
+      },
+    };
+  }
+
+  // Resend (or any future non-SMTP provider) doesn't go through
+  // MailerService at all, but MailerModule.forRootAsync still needs a valid
+  // transport - jsonTransport is nodemailer's built-in no-op transport that
+  // never sends anything, so this stays inert.
+  return {
+    transport: { jsonTransport: true },
     defaults: {
       from: emailConfig.from,
     },

--- a/apps/api/src/app/email/email.config.ts
+++ b/apps/api/src/app/email/email.config.ts
@@ -1,6 +1,12 @@
 import { ConfigService } from '@nestjs/config';
 import { MailerOptions } from '@nestjs-modules/mailer';
 
+const DEFAULT_EMAIL_PROVIDER = 'mailtrap';
+const DEFAULT_EMAIL_FROM = 'no-reply@example.com';
+const DEFAULT_SMTP_PORT = '2525';
+const DEFAULT_MAILPIT_HOST = 'localhost';
+const DEFAULT_MAILPIT_PORT = '1025';
+
 interface MailtrapConfig {
   host: string;
   port: number;
@@ -38,8 +44,9 @@ function getRequiredValue(configService: ConfigService, key: string): string {
 
 export function getEmailConfig(configService: ConfigService): EmailConfig {
   const provider =
-    (configService.get<string>('EMAIL_PROVIDER') as string) ?? 'mailtrap';
-  const from = configService.get<string>('SMTP_FROM') ?? 'no-reply@example.com';
+    (configService.get<string>('EMAIL_PROVIDER') as string) ??
+    DEFAULT_EMAIL_PROVIDER;
+  const from = configService.get<string>('SMTP_FROM') ?? DEFAULT_EMAIL_FROM;
 
   switch (provider) {
     case 'resend':
@@ -55,8 +62,11 @@ export function getEmailConfig(configService: ConfigService): EmailConfig {
         provider,
         from,
         mailpit: {
-          host: configService.get<string>('MAILPIT_HOST') ?? 'localhost',
-          port: Number(configService.get<string>('MAILPIT_PORT') ?? '1025'),
+          host:
+            configService.get<string>('MAILPIT_HOST') ?? DEFAULT_MAILPIT_HOST,
+          port: Number(
+            configService.get<string>('MAILPIT_PORT') ?? DEFAULT_MAILPIT_PORT,
+          ),
         },
       };
     case 'mailtrap':
@@ -65,14 +75,19 @@ export function getEmailConfig(configService: ConfigService): EmailConfig {
         from,
         mailtrap: {
           host: getRequiredValue(configService, 'SMTP_HOST'),
-          port: Number(configService.get<string>('SMTP_PORT') ?? '2525'),
+          port: Number(
+            configService.get<string>('SMTP_PORT') ?? DEFAULT_SMTP_PORT,
+          ),
           secure: configService.get<string>('SMTP_SECURE') === 'true',
           user: getRequiredValue(configService, 'SMTP_USER'),
           pass: getRequiredValue(configService, 'SMTP_PASS'),
         },
       };
     default:
-      // Let email-provider.factory.ts handle unrecognized provider validation.
+      // Unrecognized provider - don't force mailtrap's SMTP_* requirements
+      // on a value that isn't mailtrap. Let the EMAIL_PROVIDER factory
+      // (email-provider.factory.ts) be the single place that rejects it via
+      // UnsupportedEmailProviderException, with a clear error message.
       return { provider, from };
   }
 }

--- a/apps/api/src/app/email/email.module.ts
+++ b/apps/api/src/app/email/email.module.ts
@@ -13,6 +13,8 @@ import { EMAIL_QUEUE } from './email.queue';
 import { EmailService } from './email.service';
 import { EmailProcessor } from './email.processor';
 import { MailtrapEmailProvider } from './providers/mailtrap-email.provider';
+import { ResendEmailProvider } from './providers/resend-email.provider';
+import { MailpitEmailProvider } from './providers/mailpit-email.provider';
 import { QueueConfigFactory } from '../queue/queue.config.factory';
 
 // NODE_ENV alone isn't a reliable signal here - the staging server on Render
@@ -70,18 +72,31 @@ const isDashboardEnabled = process.env.ENABLE_QUEUE_DASHBOARD === 'true';
     EmailService,
     EmailProcessor,
     MailtrapEmailProvider,
+    ResendEmailProvider,
+    MailpitEmailProvider,
     {
       provide: EMAIL_PROVIDER,
-      inject: [ConfigService, MailtrapEmailProvider],
+      inject: [
+        ConfigService,
+        MailtrapEmailProvider,
+        ResendEmailProvider,
+        MailpitEmailProvider,
+      ],
       useFactory: (
         configService: ConfigService,
         mailtrapEmailProvider: MailtrapEmailProvider,
+        resendEmailProvider: ResendEmailProvider,
+        mailpitEmailProvider: MailpitEmailProvider,
       ) => {
         const emailConfig = getEmailConfig(configService);
 
         switch (emailConfig.provider) {
           case 'mailtrap':
             return mailtrapEmailProvider;
+          case 'resend':
+            return resendEmailProvider;
+          case 'mailpit':
+            return mailpitEmailProvider;
           default:
             throw new UnsupportedEmailProviderException(emailConfig.provider);
         }

--- a/apps/api/src/app/email/email.module.ts
+++ b/apps/api/src/app/email/email.module.ts
@@ -6,21 +6,27 @@ import { BullBoardModule } from '@bull-board/nestjs';
 import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
 import { ExpressAdapter } from '@bull-board/express';
 import basicAuth from 'express-basic-auth';
-import { getEmailConfig, getMailerOptions } from './email.config';
-import { EMAIL_PROVIDER } from './providers/email-provider.interface';
-import { UnsupportedEmailProviderException } from './email.errors';
+import { getMailerOptions } from './email.config';
+import { emailProviderFactory } from './providers/email-provider.factory';
 import { EMAIL_QUEUE } from './email.queue';
 import { EmailService } from './email.service';
 import { EmailProcessor } from './email.processor';
-import { MailtrapEmailProvider } from './providers/mailtrap-email.provider';
-import { ResendEmailProvider } from './providers/resend-email.provider';
-import { MailpitEmailProvider } from './providers/mailpit-email.provider';
 import { QueueConfigFactory } from '../queue/queue.config.factory';
 
 // NODE_ENV alone isn't a reliable signal here - the staging server on Render
 // also runs with NODE_ENV=production. Use a dedicated flag instead, so the
 // dashboard can be deliberately enabled on staging (with auth) while staying
 // off in real production.
+//
+// TODO: this reads process.env at module-body evaluation time, which runs
+// BEFORE ConfigModule.forRoot() (in AppModule) has loaded .env into
+// process.env - AppModule imports HealthModule/AuthModule/AccountModule,
+// which all transitively import EmailModule, ahead of its own
+// ConfigModule.forRoot() call. So this flag only works via a real OS/Docker
+// env var (fine in production on Render); setting it in a local .env file
+// has no effect. See getEmailConfig()'s ConfigService-based pattern in
+// email.config.ts for the fix - move this behind an injected ConfigService
+// instead of a raw process.env read.
 const isDashboardEnabled = process.env.ENABLE_QUEUE_DASHBOARD === 'true';
 
 @Module({
@@ -68,41 +74,7 @@ const isDashboardEnabled = process.env.ENABLE_QUEUE_DASHBOARD === 'true';
         ]
       : []),
   ],
-  providers: [
-    EmailService,
-    EmailProcessor,
-    MailtrapEmailProvider,
-    ResendEmailProvider,
-    MailpitEmailProvider,
-    {
-      provide: EMAIL_PROVIDER,
-      inject: [
-        ConfigService,
-        MailtrapEmailProvider,
-        ResendEmailProvider,
-        MailpitEmailProvider,
-      ],
-      useFactory: (
-        configService: ConfigService,
-        mailtrapEmailProvider: MailtrapEmailProvider,
-        resendEmailProvider: ResendEmailProvider,
-        mailpitEmailProvider: MailpitEmailProvider,
-      ) => {
-        const emailConfig = getEmailConfig(configService);
-
-        switch (emailConfig.provider) {
-          case 'mailtrap':
-            return mailtrapEmailProvider;
-          case 'resend':
-            return resendEmailProvider;
-          case 'mailpit':
-            return mailpitEmailProvider;
-          default:
-            throw new UnsupportedEmailProviderException(emailConfig.provider);
-        }
-      },
-    },
-  ],
+  providers: [EmailService, EmailProcessor, emailProviderFactory],
   exports: [EmailService, BullModule],
 })
 export class EmailModule {}

--- a/apps/api/src/app/email/providers/email-provider.factory.spec.ts
+++ b/apps/api/src/app/email/providers/email-provider.factory.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { MailerService } from '@nestjs-modules/mailer';
+import { EMAIL_PROVIDER } from './email-provider.interface';
+import { emailProviderFactory } from './email-provider.factory';
+import { MailtrapEmailProvider } from './mailtrap-email.provider';
+import { ResendEmailProvider } from './resend-email.provider';
+import { MailpitEmailProvider } from './mailpit-email.provider';
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({ emails: { send: jest.fn() } })),
+}));
+
+describe('emailProviderFactory', () => {
+  // Deliberately does NOT register MailtrapEmailProvider/ResendEmailProvider/
+  // MailpitEmailProvider as providers - moduleRef.create() must be able to
+  // construct them on demand, exactly as it will in the real EmailModule,
+  // resolving their constructor deps (MailerService, ConfigService) from
+  // this module's injector.
+  const buildModule = (
+    values: Record<string, string | undefined>,
+  ): Promise<TestingModule> =>
+    Test.createTestingModule({
+      providers: [
+        emailProviderFactory,
+        {
+          provide: ConfigService,
+          useValue: { get: (key: string) => values[key] },
+        },
+        { provide: MailerService, useValue: { sendMail: jest.fn() } },
+      ],
+    }).compile();
+
+  it('should resolve MailtrapEmailProvider for the mailtrap provider', async () => {
+    const module = await buildModule({
+      EMAIL_PROVIDER: 'mailtrap',
+      SMTP_HOST: 'smtp.mailtrap.io',
+      SMTP_USER: 'user',
+      SMTP_PASS: 'pass',
+    });
+
+    expect(module.get(EMAIL_PROVIDER)).toBeInstanceOf(MailtrapEmailProvider);
+  });
+
+  it('should resolve ResendEmailProvider for the resend provider', async () => {
+    const module = await buildModule({
+      EMAIL_PROVIDER: 'resend',
+      RESEND_API_KEY: 'resend-key',
+    });
+
+    expect(module.get(EMAIL_PROVIDER)).toBeInstanceOf(ResendEmailProvider);
+  });
+
+  it('should resolve MailpitEmailProvider for the mailpit provider', async () => {
+    const module = await buildModule({ EMAIL_PROVIDER: 'mailpit' });
+
+    expect(module.get(EMAIL_PROVIDER)).toBeInstanceOf(MailpitEmailProvider);
+  });
+
+  it('should reject unsupported providers', async () => {
+    await expect(buildModule({ EMAIL_PROVIDER: 'sendgrid' })).rejects.toThrow(
+      'Unsupported email provider: sendgrid',
+    );
+  });
+});

--- a/apps/api/src/app/email/providers/email-provider.factory.ts
+++ b/apps/api/src/app/email/providers/email-provider.factory.ts
@@ -1,0 +1,41 @@
+import { Provider } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ModuleRef } from '@nestjs/core';
+import { getEmailConfig } from '../email.config';
+import { UnsupportedEmailProviderException } from '../email.errors';
+import { EMAIL_PROVIDER, type EmailProvider } from './email-provider.interface';
+import { MailtrapEmailProvider } from './mailtrap-email.provider';
+import { ResendEmailProvider } from './resend-email.provider';
+import { MailpitEmailProvider } from './mailpit-email.provider';
+
+// Exported as a standalone provider definition (rather than inlined in
+// EmailModule) so it can be unit tested without booting the full module -
+// which would otherwise require a real Redis connection (BullModule) and
+// SMTP transport (MailerModule).
+export const emailProviderFactory: Provider = {
+  provide: EMAIL_PROVIDER,
+  inject: [ConfigService, ModuleRef],
+  useFactory: async (
+    configService: ConfigService,
+    moduleRef: ModuleRef,
+  ): Promise<EmailProvider> => {
+    const emailConfig = getEmailConfig(configService);
+
+    // Provider classes are deliberately not registered in EmailModule's
+    // `providers` array - Nest eagerly constructs every registered provider
+    // regardless of whether this switch actually picks it, which would mean
+    // building a Resend client and an unused SMTP connection on every boot.
+    // moduleRef.create() instead constructs only the one class selected
+    // here, resolving its constructor deps from this module's injector.
+    switch (emailConfig.provider) {
+      case 'mailtrap':
+        return moduleRef.create(MailtrapEmailProvider);
+      case 'resend':
+        return moduleRef.create(ResendEmailProvider);
+      case 'mailpit':
+        return moduleRef.create(MailpitEmailProvider);
+      default:
+        throw new UnsupportedEmailProviderException(emailConfig.provider);
+    }
+  },
+};

--- a/apps/api/src/app/email/providers/mailpit-email.provider.spec.ts
+++ b/apps/api/src/app/email/providers/mailpit-email.provider.spec.ts
@@ -1,0 +1,37 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailerService } from '@nestjs-modules/mailer';
+import { testSendOptions } from '@job-tracker-lite-angular/testing';
+import { MailpitEmailProvider } from './mailpit-email.provider';
+
+describe('MailpitEmailProvider', () => {
+  let provider: MailpitEmailProvider;
+  let mailerService: { sendMail: jest.Mock };
+
+  beforeEach(async () => {
+    mailerService = {
+      sendMail: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MailpitEmailProvider,
+        { provide: MailerService, useValue: mailerService },
+      ],
+    }).compile();
+
+    provider = module.get<MailpitEmailProvider>(MailpitEmailProvider);
+  });
+
+  it('should delegate sending to the Mailpit SMTP transport', async () => {
+    await provider.send(testSendOptions);
+
+    expect(mailerService.sendMail).toHaveBeenCalledWith(testSendOptions);
+  });
+
+  it('should propagate errors from the SMTP transport', async () => {
+    const smtpError = new Error('connect ECONNREFUSED 127.0.0.1:1025');
+    mailerService.sendMail.mockRejectedValueOnce(smtpError);
+
+    await expect(provider.send(testSendOptions)).rejects.toThrow(smtpError);
+  });
+});

--- a/apps/api/src/app/email/providers/mailpit-email.provider.ts
+++ b/apps/api/src/app/email/providers/mailpit-email.provider.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { MailerService } from '@nestjs-modules/mailer';
+import {
+  type EmailProvider,
+  type SendEmailOptions,
+} from './email-provider.interface';
+
+@Injectable()
+export class MailpitEmailProvider implements EmailProvider {
+  constructor(private readonly mailerService: MailerService) {}
+
+  async send(options: SendEmailOptions): Promise<void> {
+    await this.mailerService.sendMail(options);
+  }
+}

--- a/apps/api/src/app/email/providers/resend-email.provider.spec.ts
+++ b/apps/api/src/app/email/providers/resend-email.provider.spec.ts
@@ -1,0 +1,89 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { testSendOptions } from '@job-tracker-lite-angular/testing';
+import { ResendEmailProvider } from './resend-email.provider';
+
+const send = jest.fn();
+
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send },
+  })),
+}));
+
+describe('ResendEmailProvider', () => {
+  let provider: ResendEmailProvider;
+  let configService: { get: jest.Mock };
+
+  const buildConfigService = (
+    values: Record<string, string | undefined>,
+  ): { get: jest.Mock } => ({
+    get: jest.fn((key: string) => values[key]),
+  });
+
+  beforeEach(async () => {
+    send.mockReset();
+    configService = buildConfigService({
+      EMAIL_PROVIDER: 'resend',
+      RESEND_API_KEY: 'test-api-key',
+      SMTP_FROM: 'no-reply@example.com',
+    });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResendEmailProvider,
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    provider = module.get<ResendEmailProvider>(ResendEmailProvider);
+  });
+
+  it('should send the email via the Resend API', async () => {
+    send.mockResolvedValueOnce({ data: { id: 'email-1' }, error: null });
+
+    await provider.send(testSendOptions);
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: 'no-reply@example.com',
+        to: testSendOptions.to,
+        subject: testSendOptions.subject,
+        html: testSendOptions.html,
+        text: testSendOptions.text,
+      }),
+    );
+  });
+
+  it('should use the options.from override when provided', async () => {
+    send.mockResolvedValueOnce({ data: { id: 'email-1' }, error: null });
+
+    await provider.send({ ...testSendOptions, from: 'custom@example.com' });
+
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'custom@example.com' }),
+    );
+  });
+
+  it('should throw when the Resend API returns an error', async () => {
+    send.mockResolvedValueOnce({
+      data: null,
+      error: { name: 'validation_error', message: 'Invalid `to` field' },
+    });
+
+    await expect(provider.send(testSendOptions)).rejects.toThrow(
+      'Resend API error (validation_error): Invalid `to` field',
+    );
+  });
+
+  it('should throw when RESEND_API_KEY is missing', async () => {
+    configService.get.mockImplementation(
+      (key: string) =>
+        ({ EMAIL_PROVIDER: 'resend', SMTP_FROM: 'no-reply@example.com' })[key],
+    );
+
+    await expect(provider.send(testSendOptions)).rejects.toThrow(
+      'Missing required email configuration: RESEND_API_KEY',
+    );
+  });
+});

--- a/apps/api/src/app/email/providers/resend-email.provider.ts
+++ b/apps/api/src/app/email/providers/resend-email.provider.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Resend } from 'resend';
+import { getEmailConfig } from '../email.config';
+import {
+  type EmailProvider,
+  type SendEmailOptions,
+} from './email-provider.interface';
+
+@Injectable()
+export class ResendEmailProvider implements EmailProvider {
+  // Built lazily on first send() rather than in the constructor - Nest
+  // instantiates every provider listed in EmailModule regardless of which
+  // one EMAIL_PROVIDER actually selects, so requiring RESEND_API_KEY here
+  // would break bootstrap whenever a different provider is configured.
+  private client: Resend | undefined;
+
+  constructor(private readonly configService: ConfigService) {}
+
+  async send(options: SendEmailOptions): Promise<void> {
+    const emailConfig = getEmailConfig(this.configService);
+
+    if (!emailConfig.resend) {
+      throw new Error('Missing Resend configuration');
+    }
+
+    this.client ??= new Resend(emailConfig.resend.apiKey);
+
+    const { error } = await this.client.emails.send({
+      from: options.from ?? emailConfig.from,
+      to: options.to,
+      subject: options.subject,
+      html: options.html,
+      text: options.text,
+      cc: options.cc,
+      bcc: options.bcc,
+      attachments: options.attachments?.map((attachment) => ({
+        filename: attachment.filename,
+        path: attachment.path,
+        content: attachment.content,
+        contentType: attachment.contentType,
+      })),
+    });
+
+    if (error) {
+      throw new Error(`Resend API error (${error.name}): ${error.message}`);
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,6 +4,13 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import { PrismaClientExceptionFilter } from '@job-tracker-lite-angular/prisma';
 import { setupSwagger } from './swagger.setup';
+import { getEmailConfig } from './app/email/email.config';
+import { QueueConfigFactory } from './app/queue/queue.config.factory';
+
+// Mailpit's SMTP port (MAILPIT_PORT, default 1025) is unrelated to its web
+// UI port - the web UI is only exposed via the bundled docker-compose
+// service, which always maps it to 8025.
+const MAILPIT_WEB_UI_PORT = 8025;
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -40,6 +47,21 @@ async function bootstrap() {
   if (swaggerEnabled) {
     Logger.log(
       `📖 Swagger docs available at: http://localhost:${port}/${globalPrefix}/docs`,
+    );
+  }
+
+  const emailConfig = getEmailConfig(configService);
+  if (emailConfig.provider === 'mailpit') {
+    const mailpitHost = emailConfig.mailpit?.host ?? 'localhost';
+    Logger.log(
+      `📬 Mailpit inbox available at: http://${mailpitHost}:${MAILPIT_WEB_UI_PORT}`,
+    );
+  }
+
+  const queueConfigFactory = new QueueConfigFactory(configService);
+  if (queueConfigFactory.isDashboardEnabled()) {
+    Logger.log(
+      `📊 Queue dashboard available at: http://localhost:${port}/${globalPrefix}${queueConfigFactory.getDashboardRoute()}`,
     );
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,13 @@ services:
     volumes:
       - job-tracker-shared-data:/var/lib/postgresql/data
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: job-tracker-mailpit
+    ports:
+      - "1025:1025" # SMTP - point EMAIL_PROVIDER=mailpit at this
+      - "8025:8025" # Web UI - view captured emails at http://localhost:8025
+
 volumes:
   job-tracker-shared-data:
     name: job-tracker-universal-storage

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "nestjs-zod": "^5.3.0",
         "ngx-scrollbar": "^19.1.5",
         "reflect-metadata": "^0.1.13",
+        "resend": "^6.18.0",
         "rxjs": "~7.8.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
@@ -14415,6 +14416,12 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -22787,6 +22794,12 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.3",
@@ -32690,6 +32703,12 @@
         "node": ">= 10.12"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.19",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
@@ -34492,6 +34511,27 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.0.tgz",
+      "integrity": "sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.12",
@@ -36414,6 +36454,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "nestjs-zod": "^5.3.0",
     "ngx-scrollbar": "^19.1.5",
     "reflect-metadata": "^0.1.13",
+    "resend": "^6.18.0",
     "rxjs": "~7.8.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
This pull request introduces a flexible, multi-provider email system to the API, allowing the selection of `mailtrap`, `resend`, or `mailpit` as the email provider via configuration. It refactors the email configuration and provider selection logic, adds support for the Resend and Mailpit providers, and includes comprehensive tests for the new functionality.

The most important changes are:

**Email Provider Selection and Configuration:**
- Refactored the `.env.example` and `email.config.ts` to support specifying an email provider (`mailtrap`, `resend`, `mailpit`) and their respective configuration options, with sensible defaults and validation for required fields. (`[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL24-R40)`, `[[2]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR12-R26)`, `[[3]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR40-R65)`, `[[4]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR74-R96)`, `[[5]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR112-R123)`)
- The `getMailerOptions` function now builds the appropriate transport for each provider, including a no-op transport for non-SMTP providers like Resend. (`[[1]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR74-R96)`, `[[2]](diffhunk://#diff-4a51a56bd0053a636fb100cee0368572867ef72fb5df8866f383ecaf8dd5f59fR112-R123)`)

**Provider Implementation and Factory:**
- Introduced a provider factory (`emailProviderFactory`) that dynamically instantiates the correct provider class (`MailtrapEmailProvider`, `ResendEmailProvider`, or `MailpitEmailProvider`) based on configuration, improving modularity and testability. (`[[1]](diffhunk://#diff-1e2ceefd653341f41ec37dffe014a7dd6622179ae0dd0b58baeea0671e7c80bbR1-R41)`, `[[2]](diffhunk://#diff-765bf5453aa3444b49c4f94705d847481566d43554492b4df0cdcd2a48d52ba3L69-R77)`)
- Added new provider classes for Resend (`resend-email.provider.ts`) and Mailpit (`mailpit-email.provider.ts`), each implementing the `EmailProvider` interface and handling email sending via their respective services. (`[[1]](diffhunk://#diff-96f970b937047da3eaab754321ecda7cc373b51a2fc412057990066da88a87ffR1-R49)`, `[[2]](diffhunk://#diff-64da33f0c22c265d4481e91a3189b6dee50f5b96b5fe4118c93014e9905a5c06R1-R15)`)

**Testing:**
- Added comprehensive unit tests for the new configuration logic, provider factory, and each email provider, ensuring correct instantiation, configuration, and error handling. (`[[1]](diffhunk://#diff-03af5dbb2f3a54210a4d7499846fce8d6cd803bec98be74467fefb62f5978dc8R1-R153)`, `[[2]](diffhunk://#diff-8e980214cffbf4e970c8d8770c3eb54be5e04b55e34a03bda81fa06204321cf8R1-R65)`, `[[3]](diffhunk://#diff-e1932a48e3305189cd01b8ac94e87d9c06e6029c7b3f78e9c51ed31d2b8509a4R1-R89)`, `[[4]](diffhunk://#diff-5e5cf5c517721daa8e22e2da4035b27f9f41e34b49e9c681713d119469ceb88bR1-R37)`)

These changes make it easy to switch email providers for different environments (production, staging, development) and improve the maintainability and extensibility of the email subsystem.

closes #114 