### PR TITLE
refactor(zod-transform): one-validator typesafety

### DIFF
--- a/apps/frontend/src/app/shared/confirmation-dialog/confirmation-dialog.component.ts
+++ b/apps/frontend/src/app/shared/confirmation-dialog/confirmation-dialog.component.ts
@@ -25,7 +25,7 @@ import { HlmInputImports } from '@spartan-ng/helm/input';
 import { HlmFieldImports } from '@spartan-ng/helm/field';
 import {
   isBackendError,
-  ZodTransformPipFirst,
+  ZodTransformPipeFirst,
 } from '@job-tracker-lite-angular/frontend-data-access';
 import { CancelButtonComponent } from '@job-tracker-lite-angular/frontend-shared';
 import { TranslocoModule, translateSignal } from '@jsverse/transloco';
@@ -92,7 +92,7 @@ export type ConfirmationDialogContext = {
     FormRoot,
     FormField,
     TranslocoModule,
-    ZodTransformPipFirst,
+    ZodTransformPipeFirst,
   ],
   providers: [provideIcons({ lucideTrash })],
   templateUrl: './confirmation-dialog.component.html',

--- a/libs/frontend/package.json
+++ b/libs/frontend/package.json
@@ -10,7 +10,8 @@
     "@jsverse/transloco-messageformat": "^8.4.0",
     "@job-tracker-lite-angular/schemas": "0.0.1",
     "@job-tracker-lite-angular/prisma": "0.0.1",
-    "@spartan-ng/brain": "1.1.0"
+    "@spartan-ng/brain": "1.1.0",
+    "zod": "^4.4.3"
   },
   "sideEffects": false
 }

--- a/libs/frontend/src/lib/pipes/zod-transform.pipe.spec.ts
+++ b/libs/frontend/src/lib/pipes/zod-transform.pipe.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { ValidationError, WithFieldTree } from '@angular/forms/signals';
 import {
-  ZodTransformPipFirst,
+  ZodTransformPipeFirst,
   ZodTransformPipeAll,
 } from './zod-transform.pipe';
 import {
@@ -9,13 +10,13 @@ import {
   zodIssuePasswordTooShort,
 } from '@job-tracker-lite-angular/testing';
 
-describe('ZodTransformPipFirst', () => {
+describe('ZodTransformPipeFirst', () => {
   it('should transform the first Zod error item into a token', () => {
-    const pipe = new ZodTransformPipFirst();
+    const pipe = new ZodTransformPipeFirst();
     const errors = [
       { issue: zodIssueInvalidEmail },
       { issue: zodIssueWeakPassword },
-    ];
+    ] as unknown as WithFieldTree<ValidationError>[];
 
     const result = pipe.transform(errors, 'login');
 
@@ -30,7 +31,7 @@ describe('ZodTransformPipFirst', () => {
   });
 
   it('should return null when there are no errors', () => {
-    const pipe = new ZodTransformPipFirst();
+    const pipe = new ZodTransformPipeFirst();
 
     expect(pipe.transform([], 'login')).toBeNull();
     expect(pipe.transform(null, 'login')).toBeNull();
@@ -45,7 +46,7 @@ describe('ZodTransformPipeAll', () => {
       { issue: zodIssueInvalidEmail },
       { issue: zodIssueWeakPassword },
       { issue: zodIssuePasswordTooShort },
-    ];
+    ] as unknown as WithFieldTree<ValidationError>[];
 
     const result = pipe.transform(errors, 'register');
 

--- a/libs/frontend/src/lib/pipes/zod-transform.pipe.ts
+++ b/libs/frontend/src/lib/pipes/zod-transform.pipe.ts
@@ -1,38 +1,69 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import type { ValidationError, WithFieldTree } from '@angular/forms/signals';
 import {
   transformZodIssue,
   transformZodIssues,
+  type IssueLike,
 } from '../utils/error-transformer';
 
+/**
+ * Signal Forms `errors()` returns mixed error types: Zod-origin errors
+ * (`kind: 'standardSchema'`, with `.issue`) AND native Signal Forms errors
+ * as well (e.g. `required`, `minlength` — these do NOT have `.issue`).
+ *
+ * - For Zod errors: if `.issue` exists, forward it (code, path, etc.)
+ *   regardless of `kind`.
+ * - For native errors: there is no Zod issue, so we use `kind`
+ *   (e.g. 'required') as errorCode so there is something to translate and
+ *   the error does not silently pass through.
+ */
+function toIssueLike(error: WithFieldTree<ValidationError>): IssueLike {
+  if ('issue' in error && error.issue) {
+    return error.issue as IssueLike;
+  }
+
+  return {
+    errorCode: error.kind,
+    message: error.message,
+    path: [],
+  };
+}
+
+/**
+ * Angular pipe to transform Signal Forms validation errors into a format
+ * suitable for i18n translation.
+ */
 @Pipe({
   name: 'zodTransformFirst',
   standalone: true,
 })
-/**
- * Angular pipe to transform Zod validation errors into a format suitable for i18n translation.
- */
-export class ZodTransformPipFirst implements PipeTransform {
-  transform(errors: any[] | null | undefined, namespace: string): any {
+export class ZodTransformPipeFirst implements PipeTransform {
+  transform(
+    errors: WithFieldTree<ValidationError>[] | null | undefined,
+    namespace: string,
+  ) {
     if (!errors || errors.length === 0) return null;
 
-    // Take the first issue from the array and transform it
-    const firstIssue = errors[0].issue;
-    return transformZodIssue(firstIssue, namespace);
+    return transformZodIssue(toIssueLike(errors[0]), namespace);
   }
 }
+
 /**
- * Angular pipe to transform all Zod validation errors into a format suitable for i18n translation.
+ * Angular pipe to transform all Signal Forms validation errors into a
+ * format suitable for i18n translation.
  */
 @Pipe({
   name: 'zodTransformAll',
   standalone: true,
 })
 export class ZodTransformPipeAll implements PipeTransform {
-  transform(errors: any[] | null | undefined, namespace: string): any {
+  transform(
+    errors: WithFieldTree<ValidationError>[] | null | undefined,
+    namespace: string,
+  ) {
     if (!errors || errors.length === 0) return null;
 
-    const issues = errors.map((e) => e.issue);
-
+    const issues = errors.map(toIssueLike);
     return transformZodIssues(issues, namespace);
   }
 }

--- a/libs/frontend/src/lib/utils/error-transformer.spec.ts
+++ b/libs/frontend/src/lib/utils/error-transformer.spec.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   transformZodIssue,
   transformZodIssues,
-} from '../utils/error-transformer';
+  type IssueLike,
+} from './error-transformer';
 import {
   buildZodIssue,
   zodIssueInvalidEmail,
@@ -35,7 +36,7 @@ describe('transformZodIssue', () => {
   it('should use a global key when no path is provided', () => {
     const issue = buildZodIssue({ path: undefined, code: 'custom_error' });
 
-    const result = transformZodIssue(issue as any, 'register');
+    const result = transformZodIssue(issue as IssueLike, 'register');
 
     expect(result.key).toBe('register.global.custom_error');
   });
@@ -68,8 +69,14 @@ describe('transformZodIssues', () => {
   });
 
   it('should return an empty array when the input is not a valid issue list', () => {
-    expect(transformZodIssues(null as any, 'login')).toEqual([]);
-    expect(transformZodIssues(undefined as any, 'login')).toEqual([]);
-    expect(transformZodIssues('not-an-array' as any, 'login')).toEqual([]);
+    expect(transformZodIssues(null as unknown as IssueLike[], 'login')).toEqual(
+      [],
+    );
+    expect(
+      transformZodIssues(undefined as unknown as IssueLike[], 'login'),
+    ).toEqual([]);
+    expect(
+      transformZodIssues('not-an-array' as unknown as IssueLike[], 'login'),
+    ).toEqual([]);
   });
 });

--- a/libs/frontend/src/lib/utils/error-transformer.ts
+++ b/libs/frontend/src/lib/utils/error-transformer.ts
@@ -1,7 +1,43 @@
+import { z } from 'zod';
+
 export interface TranslocoToken {
   key: string; // ex. "login.email.invalid_format"
-  params: Record<string, any>; // ex. { format: "email", pattern: "..." }
+  params: Record<string, unknown>; // ex. { format: "email", pattern: "..." }
 }
+
+/**
+ * The Standard Schema spec (implemented by Angular Signal Forms
+ * `validateStandardSchema` and by Zod itself) allows path elements to be
+ * either plain PropertyKeys or an object with { key: PropertyKey }.
+ * In practice Zod always returns a plain PropertyKey, but the type must
+ * follow the specification.
+ */
+type PathSegment = PropertyKey | { key: PropertyKey };
+
+function normalizePathSegment(segment: PathSegment): PropertyKey {
+  return typeof segment === 'object' ? segment.key : segment;
+}
+
+/**
+ * A "loose" issue shape for non-Zod-origin errors (for example, a backend
+ * error response that has no `.issue`).
+ */
+export interface LooseIssue {
+  code?: string;
+  errorCode?: string;
+  path?: PathSegment[];
+  message?: string;
+}
+
+/**
+ * The minimal guaranteed contract for real Zod issues is defined by Zod's own
+ * $ZodIssueBase interface (code optional, path/message required), plus our
+ * own errorCode field — OR a loose, validated non-Zod error.
+ */
+export type IssueLike =
+  | (z.core.$ZodIssueBase & { errorCode?: string })
+  | LooseIssue;
+
 /**
  * Converts a single Zod issue into a TranslocoToken that can be used for i18n error messages.
  * @param issue Zod issue
@@ -11,31 +47,36 @@ export interface TranslocoToken {
  * and relevant parameters for translation.
  */
 export function transformZodIssue(
-  issue: any,
+  issue: IssueLike,
   formNamespace: string,
 ): TranslocoToken {
-  const pathKey = issue.path?.join('.') || 'global';
-  const finalErrorCode = issue.errorCode || issue.code || 'unknown_error';
+  const path = issue.path ?? [];
+  const pathKey =
+    path.length > 0 ? path.map(normalizePathSegment).join('.') : 'global';
+  const finalErrorCode = issue.errorCode ?? issue.code ?? 'unknown_error';
 
   const key = `${formNamespace}.${pathKey}.${finalErrorCode}`;
-
   // Filter out the standard Zod issue properties and keep only the relevant ones for
   // translation parameters
-  const ignoredKeys = ['code', 'path', 'message', 'origin', 'errorCode'];
-  const restParams = Object.keys(issue).reduce(
-    (acc, currentKey) => {
-      if (!ignoredKeys.includes(currentKey)) {
-        acc[currentKey] = (issue as any)[currentKey];
+  const ignoredKeys = new Set<string>([
+    'code',
+    'path',
+    'message',
+    'origin',
+    'errorCode',
+  ]);
+
+  const restParams = Object.entries(issue).reduce<Record<string, unknown>>(
+    (acc, [currentKey, value]) => {
+      if (!ignoredKeys.has(currentKey)) {
+        acc[currentKey] = value;
       }
       return acc;
     },
-    {} as Record<string, any>,
+    {},
   );
 
-  return {
-    key,
-    params: restParams,
-  };
+  return { key, params: restParams };
 }
 
 /**
@@ -47,13 +88,10 @@ export function transformZodIssue(
  * structured key and relevant parameters for translation.
  */
 export function transformZodIssues(
-  issues: any[],
+  issues: IssueLike[],
   formNamespace: string,
 ): TranslocoToken[] {
   if (!issues || !Array.isArray(issues)) return [];
 
-  return issues.map((err) => {
-    const actualIssue = err.issue || err;
-    return transformZodIssue(actualIssue, formNamespace);
-  });
+  return issues.map((issue) => transformZodIssue(issue, formNamespace));
 }


### PR DESCRIPTION
### Type safety and test improvements

* Updated the types in pipes and tests to use `WithFieldTree<ValidationError>` and `IssueLike`, improving type safety and test accuracy. [[1]](diffhunk://#diff-76fbc2346dc2851ecd41cc882f896224eb48ffab74ff33b1d5062737acedf7d3L12-R19) [[2]](diffhunk://#diff-76fbc2346dc2851ecd41cc882f896224eb48ffab74ff33b1d5062737acedf7d3L48-R49) [[3]](diffhunk://#diff-a2a55a1a736e09a05dba5522c332f491315909913a2b45939b3065316a0fb245L5-R6) [[4]](diffhunk://#diff-a2a55a1a736e09a05dba5522c332f491315909913a2b45939b3065316a0fb245L38-R39) [[5]](diffhunk://#diff-a2a55a1a736e09a05dba5522c332f491315909913a2b45939b3065316a0fb245L71-R80)

These changes make error handling more robust, ensure all validation errors are properly translated, and improve code clarity and maintainability.



closes #113 